### PR TITLE
Add GuardDuty detector feature for other services

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -92,3 +92,113 @@ variable "s3_protection_enabled" {
   type        = bool
   default     = false
 }
+
+variable "kubernetes_protection_enabled" {
+  description = <<-DOC
+  Flag to indicate whether EKS Protection with EKS Audit Log Monitoring Configuration will be turned on in GuardDuty.
+
+  For more information, see:
+  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "malware_protection_enabled" {
+  description = <<-DOC
+  Flag to indicate whether Malware Protection for EC2 will be turned on in GuardDuty.
+
+  For more information, see:
+  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "enable_eks_runtime_monitor" {
+  description = <<-DOC
+  Flag to indicate whether EKS Runtime Monitoring will be enabled in GuardDuty.
+
+  For more information, see:
+  https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "enable_fargate_runtime_monitor" {
+  description = <<-DOC
+  Flag to indicate whether ECS Fargate Runtime Monitoring will be enabled in GuardDuty.
+
+  For more information, see:
+  https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "enable_ec2_runtime_monitor" {
+  description = <<-DOC
+  Flag to indicate whether EC2 Runtime Monitoring will be enabled in GuardDuty.
+
+  For more information, see:
+  https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "enable_eks_audit_logs" {
+  description = <<-DOC
+  Flag to indicate whether EKS Audit Logs will be enabled in GuardDuty.
+
+  For more information, see:
+  https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "enable_ebs_malware_protection" {
+  description = <<-DOC
+  Flag to indicate whether EKS Audit Logs will be enabled in GuardDuty.
+
+  For more information, see:
+  https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "enable_rds_login_events" {
+  description = <<-DOC
+  Flag to indicate whether EKS Audit Logs will be enabled in GuardDuty.
+
+  For more information, see:
+  https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "enable_lambda_network_logs" {
+  description = <<-DOC
+  Flag to indicate whether EKS Audit Logs will be enabled in GuardDuty.
+
+  For more information, see:
+  https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "enable_s3_data_events" {
+  description = <<-DOC
+  Flag to indicate whether EKS Audit Logs will be enabled in GuardDuty.
+
+  For more information, see:
+  https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html
+  DOC
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Added other Guardduty detectors features such as EKS, S3, Lambda and RDS.
## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- There are some additional services that Guardduty Detector started to support, but not added to the module.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://docs.aws.amazon.com/guardduty/latest/ug/guardduty-features-activation-model.html#guardduty-features
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector_feature
- https://docs.aws.amazon.com/guardduty/latest/APIReference/API_DetectorFeatureConfiguration.html
- https://docs.aws.amazon.com/guardduty/latest/APIReference/API_DetectorAdditionalConfiguration.html

closes #17